### PR TITLE
parameterize image registry

### DIFF
--- a/e2e/configuration/policy-values.yaml
+++ b/e2e/configuration/policy-values.yaml
@@ -1,21 +1,24 @@
 global:
+  registryOverride: "quay.io"
+  # registry for ACM 2.11.2
+  # registryOverride: "registry.redhat.io"
   imageOverrides:
     # upstream images
-    governance_policy_propagator: "quay.io/stolostron/governance-policy-propagator:2.12.0-SNAPSHOT-2024-09-30-01-46-06"
-    governance_policy_addon_controller: "quay.io/stolostron/governance-policy-addon-controller:2.12.0-SNAPSHOT-2024-09-30-01-46-06" 
-    config_policy_controller: "quay.io/stolostron/config-policy-controller:2.12.0-SNAPSHOT-2024-09-30-01-46-06"
-    governance_policy_framework_addon: "quay.io/stolostron/governance-policy-framework-addon:2.12.0-SNAPSHOT-2024-09-30-01-46-06"
-    klusterlet_addon_controller: "quay.io/stolostron/klusterlet-addon-controller:2.12.0-SNAPSHOT-2024-09-30-01-46-06"
- 
+    governance_policy_propagator: "stolostron/governance-policy-propagator:2.12.0-SNAPSHOT-2024-09-30-01-46-06"
+    governance_policy_addon_controller: "stolostron/governance-policy-addon-controller:2.12.0-SNAPSHOT-2024-09-30-01-46-06" 
+    config_policy_controller: "stolostron/config-policy-controller:2.12.0-SNAPSHOT-2024-09-30-01-46-06"
+    governance_policy_framework_addon: "stolostron/governance-policy-framework-addon:2.12.0-SNAPSHOT-2024-09-30-01-46-06"
+    klusterlet_addon_controller: "stolostron/klusterlet-addon-controller:2.12.0-SNAPSHOT-2024-09-30-01-46-06"
+
     # images in ACM 2.11.2
-    # governance_policy_propagator: "registry.redhat.io/rhacm2/governance-policy-propagator-rhel9@sha256:af848e7e31d8ec9b5ad1896a5d5ccc67f320a7740245c190ba8a76757984e65b"
-    # governance_policy_addon_controller: "registry.redhat.io/rhacm2/acm-governance-policy-addon-controller-rhel9@sha256:fc0708f0a6d5266fb544f41b61d9697d370c8c5e297e4e3f13de8656f9c2b049" 
-    # config_policy_controller: "registry.redhat.io/rhacm2/config-policy-controller-rhel9@sha256:cecf914d7fb7759a4f512c1ec53a077dcb1c7e405c22a5bf6af1bf5878cf3c42"
-    # governance_policy_framework_addon: "registry.redhat.io/rhacm2/acm-governance-policy-framework-addon-rhel9@sha256:a4880f6e82d2b82606203ea855d0418bb29b3d4535f8bc7a9ef4074258c18674"
-    # klusterlet_addon_controller: "registry.redhat.io/rhacm2/klusterlet-addon-controller-rhel9@sha256:478e3e6cda0d74f43b0f05911d023344108a5cd79d57d5cc9f268ad064848a00"
+    # governance_policy_propagator: "rhacm2/governance-policy-propagator-rhel9@sha256:af848e7e31d8ec9b5ad1896a5d5ccc67f320a7740245c190ba8a76757984e65b"
+    # governance_policy_addon_controller: "rhacm2/acm-governance-policy-addon-controller-rhel9@sha256:fc0708f0a6d5266fb544f41b61d9697d370c8c5e297e4e3f13de8656f9c2b049" 
+    # config_policy_controller: "rhacm2/config-policy-controller-rhel9@sha256:cecf914d7fb7759a4f512c1ec53a077dcb1c7e405c22a5bf6af1bf5878cf3c42"
+    # governance_policy_framework_addon: "rhacm2/acm-governance-policy-framework-addon-rhel9@sha256:a4880f6e82d2b82606203ea855d0418bb29b3d4535f8bc7a9ef4074258c18674"
+    # klusterlet_addon_controller: "rhacm2/klusterlet-addon-controller-rhel9@sha256:478e3e6cda0d74f43b0f05911d023344108a5cd79d57d5cc9f268ad064848a00"
   namespace: multicluster-engine
   pullSecret: open-cluster-management-image-pull-credentials
-  
+
   cma:
     defaultConfig:
       name: addon-hosted-config

--- a/policy/charts/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml
+++ b/policy/charts/cluster-lifecycle/templates/klusterlet-addon-deployment.yaml
@@ -79,7 +79,7 @@ spec:
       {{- end }}
       containers:
       - name: klusterlet-addon-controller
-        image: "{{ .Values.global.imageOverrides.klusterlet_addon_controller }}"
+        image: "{{ .Values.global.registryOverride}}/{{ .Values.global.imageOverrides.klusterlet_addon_controller }}"
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         securityContext:
           allowPrivilegeEscalation: false

--- a/policy/charts/grc/templates/grc-policy-addon-controller.yaml
+++ b/policy/charts/grc/templates/grc-policy-addon-controller.yaml
@@ -69,10 +69,10 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         - name: CONFIG_POLICY_CONTROLLER_IMAGE
-          value: {{ .Values.global.imageOverrides.config_policy_controller }}
+          value: "{{ .Values.global.registryOverride}}/{{ .Values.global.imageOverrides.config_policy_controller }}"
         - name: GOVERNANCE_POLICY_FRAMEWORK_ADDON_IMAGE
-          value: {{ .Values.global.imageOverrides.governance_policy_framework_addon }}
-        image: {{ .Values.global.imageOverrides.governance_policy_addon_controller }}
+          value: "{{ .Values.global.registryOverride}}/{{ .Values.global.imageOverrides.governance_policy_framework_addon }}"
+        image: "{{ .Values.global.registryOverride}}/{{ .Values.global.imageOverrides.governance_policy_addon_controller }}"
         imagePullPolicy: IfNotPresent
         name: manager
         resources:

--- a/policy/charts/grc/templates/grc-policy-propagator.yaml
+++ b/policy/charts/grc/templates/grc-policy-propagator.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.name
         - name: OPERATOR_NAME
           value: governance-policy-propagator
-        image: {{ .Values.global.imageOverrides.governance_policy_propagator }}
+        image: "{{ .Values.global.registryOverride}}/{{ .Values.global.imageOverrides.governance_policy_propagator }}"
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:

--- a/policy/charts/grc/values.yaml
+++ b/policy/charts/grc/values.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2020 Red Hat, Inc.
 
 global:
+  registryOverride: ""
   imageOverrides:
     governance_policy_propagator: ""
     governance_policy_addon_controller: ""

--- a/policy/values.yaml
+++ b/policy/values.yaml
@@ -1,10 +1,11 @@
 global:
+  registryOverride: "registry.redhat.io"
   imageOverrides:
-    governance_policy_propagator: "registry.redhat.io/rhacm2/governance-policy-propagator-rhel9@sha256:f2fa1a7c7af6379eda44a691de57eb59dc8068aadb98504df7ef4a5e059a0cfa"
-    governance_policy_addon_controller: "registry.redhat.io/rhacm2/acm-governance-policy-addon-controller-rhel9@sha256:7b2f432d7ea6b9eb9c4df6df88ae3d5bfc261a8d24a5146a04d3465a41d99e10"
-    config_policy_controller: "registry.redhat.io/rhacm2/config-policy-controller-rhel9@sha256:bad96b2cd7efd604b3ef8092eb72c5a7d33b39732a1a8fe995aa197ead7a5d31"
-    governance_policy_framework_addon: "registry.redhat.io/rhacm2/acm-governance-policy-framework-addon-rhel9@sha256:a5373e3aed5c8e0ac1427599c3801eccd3b4ff4bdc3f9c0cd7083ff3e34433b3"
-    klusterlet_addon_controller: "registry.redhat.io/rhacm2/klusterlet-addon-controller-rhel9@sha256:f8188bc955dbc635031e765fb09015926eb350a7484e6c9f2e0af6020e02aa30"
+    governance_policy_propagator: "rhacm2/governance-policy-propagator-rhel9@sha256:f2fa1a7c7af6379eda44a691de57eb59dc8068aadb98504df7ef4a5e059a0cfa"
+    governance_policy_addon_controller: "rhacm2/acm-governance-policy-addon-controller-rhel9@sha256:7b2f432d7ea6b9eb9c4df6df88ae3d5bfc261a8d24a5146a04d3465a41d99e10"
+    config_policy_controller: "rhacm2/config-policy-controller-rhel9@sha256:bad96b2cd7efd604b3ef8092eb72c5a7d33b39732a1a8fe995aa197ead7a5d31"
+    governance_policy_framework_addon: "rhacm2/acm-governance-policy-framework-addon-rhel9@sha256:a5373e3aed5c8e0ac1427599c3801eccd3b4ff4bdc3f9c0cd7083ff3e34433b3"
+    klusterlet_addon_controller: "rhacm2/klusterlet-addon-controller-rhel9@sha256:f8188bc955dbc635031e765fb09015926eb350a7484e6c9f2e0af6020e02aa30"
 
   namespace: multicluster-engine
   pullSecret: open-cluster-management-image-pull-credentials


### PR DESCRIPTION
introduce a value parameter `global.registryOverride` and turn `imageOverrides` into image references relative to that registry

this allows us to still keep using the image defaults as defined in this chart but override the registry they are pulled from.